### PR TITLE
Added a service to control a fan connected on GPIO11

### DIFF
--- a/roles/pirogue/handlers/main.yml
+++ b/roles/pirogue/handlers/main.yml
@@ -11,4 +11,9 @@
 - name: reload locales
   command: locale-gen
     
-    
+- name: restart fan-control
+  systemd:
+    name: "fan-control"
+    enabled: yes
+    state: "restarted"
+    daemon_reload: yes

--- a/roles/pirogue/tasks/fan-control.yml
+++ b/roles/pirogue/tasks/fan-control.yml
@@ -1,0 +1,15 @@
+---
+
+- name: python3-rpi.gpio is installed
+  apt:
+    pkg: "python3-rpi.gpio"
+    state: "present"
+    update_cache: yes
+    cache_valid_time: 10800
+    
+- name: Add the service to control a fan connected on GPIO 11 (be careful it needs some electronic stuff to protect your pi parts)
+  file:
+    src: /usr/share/PiRogue/fan-control/fan-control.service
+    dest: /etc/systemd/system/fan-control.service
+    state: link
+  notify: restart fan-control

--- a/roles/pirogue/tasks/main.yml
+++ b/roles/pirogue/tasks/main.yml
@@ -113,6 +113,7 @@
     dest: /etc/cron.d/pirogue
 
 - include: "enable-i2c.yml"
+- include: "fan-control.yml"
 
 - name: Add the service displaying details on screen
   file:


### PR DESCRIPTION
on intensive loads our PiRogue can get quite hot and performance may dicrease.

This service allows you to control a fan connected on GPIO11 (some electronics must be added to control the fan and protect the raspberrypi).

Successfully tested with a DC 5V motor.

Schematics may follow on PiRogue/doc repository